### PR TITLE
draw_frame specify frame #

### DIFF
--- a/Packages/vcs/Lib/VTKAnimate.py
+++ b/Packages/vcs/Lib/VTKAnimate.py
@@ -40,9 +40,16 @@ class VTKAnimate(animate_helper.AnimationController):
         self.cleared = False
         import atexit
         atexit.register(self.close)
-    def draw_frame(self):
+
+    def draw_frame(self, frame_num = None):
+      if frame_num is None:
+        frame_num = self.frame_num
+      else:
+        self.frame_num = frame_num
+      #print "Drawing frame:",self.frame_num,self._unique_prefix
       png_name=os.path.join(os.environ["HOME"],".uvcdat",self._unique_prefix,"anim_%i.png" % self.frame_num)
       if os.path.exists(png_name) and len(self.animation_files)==self.number_of_frames():
+
         ## Ok we have the pngs and we need to zoom, need to use png
         ## maybe the zoom factor thing can be taken off, not sure what's faster
         if not self.cleared:
@@ -78,4 +85,4 @@ class VTKAnimate(animate_helper.AnimationController):
         self.vcs_self.png(png_name)
         self.animation_files = sorted(glob.glob(os.path.join(os.path.dirname(png_name),"*.png")))
       if self.signals is not None:
-        self.signals.drawn.emit(self.frame_num)
+        self.signals.drawn.emit(frame_num)

--- a/Packages/vcs/Lib/VTKAnimate.py
+++ b/Packages/vcs/Lib/VTKAnimate.py
@@ -85,4 +85,4 @@ class VTKAnimate(animate_helper.AnimationController):
         self.vcs_self.png(png_name)
         self.animation_files = sorted(glob.glob(os.path.join(os.path.dirname(png_name),"*.png")))
       if self.signals is not None:
-        self.signals.drawn.emit(frame_num)
+        self.signals.drawn.emit(self.frame_num)

--- a/Packages/vcs/Lib/VTKPlots.py
+++ b/Packages/vcs/Lib/VTKPlots.py
@@ -210,6 +210,10 @@ class VTKVCSBackend(object):
     self.canvas.clear()
     for i, pargs in enumerate(plots_args):
       self.canvas.plot(*pargs,**key_args[i])
+
+    if self.canvas.animate.created():
+      self.canvas.animate.draw_frame()
+
     if self.renWin.GetSize()!=(0,0):
       self.scaleLogo()
     if self.renWin is not None and sys.platform == "darwin":


### PR DESCRIPTION
draw_frame() will now accept an (optional) frame_num argument to specify which frame to draw
configureEvent() was blowing away the current frame, so it will now check if the animation is created, and if so, draw the current frame.
